### PR TITLE
implementation of DataContract Create/Update Transtion

### DIFF
--- a/dpp/src/convertible.rs
+++ b/dpp/src/convertible.rs
@@ -1,0 +1,15 @@
+use crate::ProtocolError;
+use serde_json::Value as JsonValue;
+
+pub trait Convertible {
+    /// Returns the [`serde_json::Value`] instance that preserves the `Vec<u8>` representation
+    /// for Identifiers and binary data
+    fn to_object(&self) -> Result<JsonValue, ProtocolError>;
+    /// Returns the [`serde_json::Value`] instance that encodes:
+    ///  - Identifiers  - with base58
+    ///  - Binary data  - with base64
+    fn to_json(&self) -> Result<JsonValue, ProtocolError>;
+    // Returns the cibor-encoded bytes representation of the object. The data is prefixed by 4 bytes containing
+    // the Protocol Version
+    fn to_buffer(&self) -> Result<Vec<u8>, ProtocolError>;
+}

--- a/dpp/src/data_contract/data_contract.rs
+++ b/dpp/src/data_contract/data_contract.rs
@@ -305,7 +305,7 @@ mod test {
         let string_contract = get_data_from_file("src/tests/payloads/contract_example.json")?;
         let data_contract: DataContract = serde_json::from_str(&string_contract)?;
 
-        let raw_data_contract = data_contract.to_object(false)?;
+        let raw_data_contract = data_contract.to_object()?;
         for path in IDENTIFIER_FIELDS {
             assert!(raw_data_contract
                 .get(path)

--- a/dpp/src/data_contract/data_contract.rs
+++ b/dpp/src/data_contract/data_contract.rs
@@ -49,6 +49,10 @@ impl DataContract {
         Self::default()
     }
 
+    pub fn from_raw_object(raw_object: JsonValue) -> Result<DataContract, ProtocolError> {
+        todo!()
+    }
+
     pub fn from_buffer(b: impl AsRef<[u8]>) -> Result<DataContract, ProtocolError> {
         let (protocol_bytes, document_bytes) = b.as_ref().split_at(4);
 

--- a/dpp/src/data_contract/data_contract.rs
+++ b/dpp/src/data_contract/data_contract.rs
@@ -2,6 +2,7 @@ use super::errors::*;
 use crate::data_contract::get_binary_properties_from_schema::get_binary_properties;
 use crate::util::json_value::{JsonValueExt, ReplaceWith};
 use crate::util::string_encoding::Encoding;
+use crate::Convertible;
 use crate::{
     errors::ProtocolError,
     identifier::Identifier,
@@ -21,6 +22,7 @@ const PROPERTY_VERSION: &str = "version";
 const PROPERTY_SCHEMA: &str = "$schema";
 const PROPERTY_DOCUMENTS: &str = "documents";
 const PROPERTY_DEFINITIONS: &str = "$defs";
+const PROPERTY_ENTROPY: &str = "entropy";
 
 pub type JsonSchema = JsonValue;
 type DocumentType = String;
@@ -28,7 +30,37 @@ type PropertyPath = String;
 
 pub const SCHEMA: &str = "https://schema.dash.org/dpp-0-4-0/meta/data-contract";
 
-pub const IDENTIFIER_FIELDS: [&str; 2] = ["$id", "ownerId"];
+pub const IDENTIFIER_FIELDS: [&str; 2] = [PROPERTY_ID, PROPERTY_OWNER_ID];
+
+impl Convertible for DataContract {
+    fn to_object(&self) -> Result<JsonValue, ProtocolError> {
+        let mut json_object = serde_json::to_value(&self)?;
+        if !json_object.is_object() {
+            return Err(anyhow!("the Data Contract isn't a JSON Value Object").into());
+        }
+
+        json_object.replace_identifier_paths(IDENTIFIER_FIELDS, ReplaceWith::Bytes)?;
+        Ok(json_object)
+    }
+
+    /// Returns Data Contract as a JSON Value
+    fn to_json(&self) -> Result<JsonValue, ProtocolError> {
+        Ok(serde_json::to_value(&self)?)
+    }
+
+    /// Returns Data Contract as a Buffer
+    fn to_buffer(&self) -> Result<Vec<u8>, ProtocolError> {
+        let protocol_version = self.protocol_version;
+        // what means skip_identifiers_conversion
+        let mut json_object = self.to_object()?;
+
+        if let JsonValue::Object(ref mut o) = json_object {
+            o.remove("protocolVersion");
+        };
+
+        serializer::value_to_cbor(json_object, Some(protocol_version))
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
@@ -73,7 +105,7 @@ impl DataContract {
         let mut json_value: JsonValue = ciborium::de::from_reader(document_bytes)
             .map_err(|e| ProtocolError::EncodingError(format!("{}", e)))?;
 
-        json_value.parse_and_add_protocol_version(protocol_bytes)?;
+        json_value.parse_and_add_protocol_version("protocolVersion", protocol_bytes)?;
 
         // TODO identifier_default_deserializer: default deserializer should be changed to bytes
         // Identifiers fields should be replaced with the string format to deserialize Data Contract
@@ -82,35 +114,6 @@ impl DataContract {
         let mut data_contract: DataContract = serde_json::from_value(json_value)?;
         data_contract.generate_binary_properties();
         Ok(data_contract)
-    }
-
-    pub fn to_object(&self, skip_identifiers_conversion: bool) -> Result<JsonValue, ProtocolError> {
-        let mut json_object = serde_json::to_value(&self)?;
-        if !json_object.is_object() {
-            return Err(anyhow!("the Data Contract isn't a JSON Value Object").into());
-        }
-
-        if !skip_identifiers_conversion {
-            json_object.replace_identifier_paths(IDENTIFIER_FIELDS, ReplaceWith::Bytes)?;
-        }
-        Ok(json_object)
-    }
-
-    /// Returns Data Contract as a JSON Value
-    pub fn to_json(&self) -> Result<JsonValue, ProtocolError> {
-        Ok(serde_json::to_value(&self)?)
-    }
-
-    /// Returns Data Contract as a Buffer
-    pub fn to_buffer(&self) -> Result<Vec<u8>, ProtocolError> {
-        let protocol_version = self.protocol_version;
-        let mut json_object = self.to_object(true)?;
-
-        if let JsonValue::Object(ref mut o) = json_object {
-            o.remove("protocolVersion");
-        };
-
-        serializer::value_to_cbor(json_object, Some(protocol_version))
     }
 
     // Returns hash from Data Contract
@@ -220,7 +223,10 @@ impl TryFrom<&str> for DataContract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{assert_error_contains, tests::utils::*};
+    use crate::{
+        assert_error_contains,
+        tests::{fixtures::get_data_contract_fixture, utils::*},
+    };
     use anyhow::Result;
 
     fn init() {
@@ -230,7 +236,32 @@ mod test {
     }
 
     #[test]
-    fn test_deserialize_contract_from_string() -> Result<()> {
+    fn conversion_to_buffer_from_buffer() {
+        init();
+        let data_contract = get_data_contract_fixture(None);
+        let data_contract_bytes = data_contract
+            .to_buffer()
+            .expect("data contract should be converted into the bytes");
+        let data_contract_restored = DataContract::from_buffer(&data_contract_bytes)
+            .expect("data contract should be created from bytes");
+
+        assert_eq!(
+            data_contract.protocol_version,
+            data_contract_restored.protocol_version
+        );
+        assert_eq!(data_contract.schema, data_contract_restored.schema);
+        assert_eq!(data_contract.version, data_contract_restored.version);
+        assert_eq!(data_contract.id, data_contract_restored.id);
+        assert_eq!(data_contract.owner_id, data_contract_restored.owner_id);
+        assert_eq!(
+            data_contract.binary_properties,
+            data_contract_restored.binary_properties
+        );
+        assert_eq!(data_contract.documents, data_contract_restored.documents);
+    }
+
+    #[test]
+    fn conversion_from_json() -> Result<()> {
         init();
 
         let string_contract = get_data_from_file("src/tests/payloads/contract_example.json")?;
@@ -256,7 +287,7 @@ mod test {
     }
 
     #[test]
-    fn test_serialize_contract_json() -> Result<()> {
+    fn conversion_to_json() -> Result<()> {
         init();
 
         let mut string_contract = get_data_from_file("src/tests/payloads/contract_example.json")?;
@@ -270,7 +301,7 @@ mod test {
     }
 
     #[test]
-    fn test_serialize_to_object() -> Result<()> {
+    fn conversion_to_object() -> Result<()> {
         let string_contract = get_data_from_file("src/tests/payloads/contract_example.json")?;
         let data_contract: DataContract = serde_json::from_str(&string_contract)?;
 
@@ -285,7 +316,7 @@ mod test {
     }
 
     #[test]
-    fn test_deserialize_contract_from_raw() -> Result<()> {
+    fn conversion_from_object() -> Result<()> {
         init();
 
         let string_contract = get_data_from_file("src/tests/payloads/contract_example.json")?;
@@ -319,7 +350,7 @@ mod test {
     }
 
     #[test]
-    fn deserialize_contract_from_invalid_raw_object() -> Result<()> {
+    fn conversion_from_invalid_object() -> Result<()> {
         init();
 
         let string_contract = get_data_from_file("src/tests/payloads/contract_example.json")?;

--- a/dpp/src/data_contract/state_transition/data_contract_create_transition/apply_data_contract_create_transition_factory.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_create_transition/apply_data_contract_create_transition_factory.rs
@@ -1,5 +1,7 @@
-use crate::{mocks, state_repository::StateRepositoryLike};
+use crate::state_repository::StateRepositoryLike;
 use anyhow::Result;
+
+use super::DataContractCreateTransition;
 
 pub struct ApplyDataContractCreateTransition<SR>
 where
@@ -21,10 +23,10 @@ where
 {
     pub async fn apply_data_contract_create_transition(
         &self,
-        state_transition: mocks::StateTransition,
+        state_transition: &DataContractCreateTransition,
     ) -> Result<()> {
         self.state_repository
-            .store_data_contract(state_transition.data_contract)
+            .store_data_contract(state_transition.data_contract.clone())
             .await
     }
 }

--- a/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
@@ -178,10 +178,7 @@ impl StateTransitionConvert for DataContractCreateTransition {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        decode_protocol_entity_factory::DecodeProtocolEntity,
-        util::deserializer::get_protocol_version, version,
-    };
+    use crate::{util::deserializer::get_protocol_version, version};
     use serde_json::json;
 
     use crate::tests::fixtures::get_data_contract_fixture;
@@ -300,5 +297,22 @@ mod test {
             version::LATEST_VERSION,
             get_protocol_version(protocol_bytes).expect("version should be valid")
         )
+    }
+
+    #[test]
+    fn should_return_owner_id() {
+        let data = get_test_data();
+        assert_eq!(
+            &data.data_contract.owner_id,
+            data.state_transition.get_owner_id()
+        );
+    }
+
+    #[test]
+    fn is_data_contract_state_transition() {
+        let data = get_test_data();
+        assert!(data.state_transition.is_data_contract_state_transition());
+        assert!(!data.state_transition.is_document_state_transition());
+        assert!(!data.state_transition.is_identity_state_transition());
     }
 }

--- a/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
@@ -7,6 +7,7 @@ use std::convert::TryInto;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
+use super::properties::*;
 use crate::{
     data_contract::DataContract,
     identity::KeyID,
@@ -18,13 +19,6 @@ use crate::{
     util::json_value::{JsonValueExt, ReplaceWith},
     ProtocolError,
 };
-
-const PROPERTY_SIGNATURE_PUBLIC_KEY_ID: &str = "signaturePublicKeyId";
-const PROPERTY_DATA_CONTRACT: &str = "dataContract";
-const PROPERTY_SIGNATURE: &str = "signature";
-const PROPERTY_ENTROPY: &str = "entropy";
-const PROPERTY_PROTOCOL_VERSION: &str = "protocolVersion";
-const PROPERTY_TRANSITION_TYPE: &str = "type";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -61,10 +55,10 @@ impl DataContractCreateTransition {
             protocol_version: raw_data_contract_update_transition
                 .get_u64(PROPERTY_PROTOCOL_VERSION)? as u32,
             signature: raw_data_contract_update_transition
-                .get_bytes(PROPERTY_SIGNATURE)
+                .remove_into(PROPERTY_SIGNATURE)
                 .unwrap_or_default(),
             signature_public_key_id: raw_data_contract_update_transition
-                .get_u64(PROPERTY_SIGNATURE)
+                .get_u64(PROPERTY_SIGNATURE_PUBLIC_KEY_ID)
                 .unwrap_or_default(),
             entropy: raw_data_contract_update_transition
                 .get_bytes(PROPERTY_ENTROPY)
@@ -246,10 +240,6 @@ mod test {
             .state_transition
             .to_json()
             .expect("conversion to JSON shouldn't fail");
-        println!(
-            "the result is {}",
-            serde_json::to_string_pretty(&json_object).unwrap()
-        );
 
         assert_eq!(
             version::LATEST_VERSION,

--- a/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
@@ -164,7 +164,7 @@ impl StateTransitionConvert for DataContractCreateTransition {
         }
         json_object.insert(
             String::from(PROPERTY_DATA_CONTRACT),
-            self.data_contract.to_object(false)?,
+            self.data_contract.to_object()?,
         )?;
         Ok(json_object)
     }
@@ -190,7 +190,7 @@ mod test {
         let state_transition = DataContractCreateTransition::from_raw_object(json!({
                     PROPERTY_PROTOCOL_VERSION: version::LATEST_VERSION,
                                         PROPERTY_ENTROPY : data_contract.entropy,
-                    PROPERTY_DATA_CONTRACT : data_contract.to_object(false).unwrap(),
+                    PROPERTY_DATA_CONTRACT : data_contract.to_object().unwrap(),
         }))
         .expect("state transition should be created without errors");
 
@@ -225,10 +225,10 @@ mod test {
         assert_eq!(
             data.state_transition
                 .get_data_contract()
-                .to_object(false)
+                .to_object()
                 .expect("conversion to object shouldn't fail"),
             data.data_contract
-                .to_object(false)
+                .to_object()
                 .expect("conversion to object shouldn't fail")
         );
     }

--- a/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
@@ -1,3 +1,179 @@
 pub mod apply_data_contract_create_transition_factory;
-
 pub mod validation;
+use anyhow::anyhow;
+
+use std::convert::TryInto;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::{
+    data_contract::DataContract,
+    identity::KeyID,
+    prelude::Identifier,
+    state_transition::{
+        StateTransitionConvert, StateTransitionIdentitySigned, StateTransitionLike,
+        StateTransitionType,
+    },
+    util::json_value::{JsonValueExt, ReplaceWith},
+    ProtocolError,
+};
+
+const PROPERTY_SIGNATURE_PUBLIC_KEY_ID: &str = "signaturePublicKeyId";
+const PROPERTY_DATA_CONTRACT: &str = "dataContract";
+const PROPERTY_SIGNATURE: &str = "signature";
+const PROPERTY_ENTROPY: &str = "entropy";
+const PROPERTY_PROTOCOL_VERSION: &str = "protocolVersion";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataContractCreateTransition {
+    pub protocol_version: u32,
+    #[serde(rename = "type")]
+    pub transition_type: StateTransitionType,
+    // we want to skip serialization of transitions, as we does it manually in `to_object()`  and `to_json()`
+    #[serde(skip_serializing)]
+    pub data_contract: DataContract,
+    pub entropy: [u8; 32],
+    pub signature_public_key_id: KeyID,
+    pub signature: Vec<u8>,
+}
+
+impl std::default::Default for DataContractCreateTransition {
+    fn default() -> Self {
+        DataContractCreateTransition {
+            protocol_version: Default::default(),
+            transition_type: StateTransitionType::DataContractCreate,
+            entropy: [0u8; 32],
+            signature_public_key_id: 0,
+            signature: vec![],
+            data_contract: DataContract::default(),
+        }
+    }
+}
+
+impl DataContractCreateTransition {
+    pub fn from_raw_object(
+        mut raw_data_contract_update_transition: JsonValue,
+    ) -> Result<DataContractCreateTransition, ProtocolError> {
+        Ok(DataContractCreateTransition {
+            protocol_version: raw_data_contract_update_transition
+                .get_u64(PROPERTY_PROTOCOL_VERSION)? as u32,
+            signature: raw_data_contract_update_transition
+                .get_bytes(PROPERTY_SIGNATURE)
+                .unwrap_or_default(),
+            signature_public_key_id: raw_data_contract_update_transition
+                .get_u64(PROPERTY_SIGNATURE)
+                .unwrap_or_default(),
+            entropy: raw_data_contract_update_transition
+                .get_bytes(PROPERTY_SIGNATURE)
+                .unwrap_or_default()
+                .try_into()
+                .map_err(|_| anyhow!("entropy isn't 32 bytes long"))?,
+            data_contract: DataContract::from_raw_object(
+                raw_data_contract_update_transition.remove(PROPERTY_DATA_CONTRACT)?,
+            )?,
+            ..Default::default()
+        })
+    }
+
+    pub fn get_data_contract(&self) -> &DataContract {
+        &self.data_contract
+    }
+
+    pub fn set_data_contract(&mut self, data_contract: DataContract) {
+        self.data_contract = data_contract;
+    }
+
+    pub fn get_entropy(&self) -> &[u8; 32] {
+        &self.entropy
+    }
+
+    /// Get owner ID
+    pub fn get_owner_id(&self) -> &Identifier {
+        &self.data_contract.owner_id
+    }
+
+    /// Returns ID of the created contract
+    pub fn get_modified_data_ids(&self) -> Vec<&Identifier> {
+        vec![&self.data_contract.id]
+    }
+}
+
+impl StateTransitionIdentitySigned for DataContractCreateTransition {
+    fn get_signature_public_key_id(&self) -> KeyID {
+        self.signature_public_key_id
+    }
+
+    fn set_signature_public_key_id(&mut self, key_id: crate::identity::KeyID) {
+        self.signature_public_key_id = key_id
+    }
+}
+
+impl StateTransitionLike for DataContractCreateTransition {
+    fn get_protocol_version(&self) -> u32 {
+        self.protocol_version
+    }
+    /// returns the type of State Transition
+    fn get_type(&self) -> StateTransitionType {
+        self.transition_type
+    }
+    /// returns the signature as a byte-array
+    fn get_signature(&self) -> &Vec<u8> {
+        &self.signature
+    }
+    /// set a new signature
+    fn set_signature(&mut self, signature: Vec<u8>) {
+        self.signature = signature
+    }
+    fn calculate_fee(&self) -> Result<u64, ProtocolError> {
+        todo!("fee calculation")
+    }
+}
+
+impl StateTransitionConvert for DataContractCreateTransition {
+    fn signature_property_paths() -> Vec<&'static str> {
+        vec![PROPERTY_SIGNATURE]
+    }
+
+    fn identifiers_property_paths() -> Vec<&'static str> {
+        vec![]
+    }
+
+    fn binary_property_paths() -> Vec<&'static str> {
+        vec![
+            PROPERTY_SIGNATURE,
+            PROPERTY_SIGNATURE_PUBLIC_KEY_ID,
+            PROPERTY_ENTROPY,
+        ]
+    }
+
+    fn to_json(&self) -> Result<JsonValue, ProtocolError> {
+        let mut json_value: JsonValue = serde_json::to_value(self)?;
+        json_value.replace_binary_paths(Self::binary_property_paths(), ReplaceWith::Base64)?;
+        json_value
+            .replace_identifier_paths(Self::identifiers_property_paths(), ReplaceWith::Base58)?;
+
+        json_value.insert(
+            PROPERTY_DATA_CONTRACT.to_string(),
+            self.data_contract.to_json()?,
+        )?;
+
+        Ok(json_value)
+    }
+
+    fn to_object(&self, skip_signature: bool) -> Result<JsonValue, ProtocolError> {
+        let mut json_object: JsonValue = serde_json::to_value(self)?;
+        if skip_signature {
+            if let JsonValue::Object(ref mut o) = json_object {
+                for path in Self::signature_property_paths() {
+                    o.remove(path);
+                }
+            }
+        }
+        json_object.insert(
+            String::from(PROPERTY_DATA_CONTRACT),
+            self.data_contract.to_object(false)?,
+        )?;
+        Ok(json_object)
+    }
+}

--- a/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
@@ -24,8 +24,10 @@ const PROPERTY_DATA_CONTRACT: &str = "dataContract";
 const PROPERTY_SIGNATURE: &str = "signature";
 const PROPERTY_ENTROPY: &str = "entropy";
 const PROPERTY_PROTOCOL_VERSION: &str = "protocolVersion";
+const PROPERTY_TRANSITION_TYPE: &str = "type";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DataContractCreateTransition {
     pub protocol_version: u32,
     #[serde(rename = "type")]
@@ -65,8 +67,8 @@ impl DataContractCreateTransition {
                 .get_u64(PROPERTY_SIGNATURE)
                 .unwrap_or_default(),
             entropy: raw_data_contract_update_transition
-                .get_bytes(PROPERTY_SIGNATURE)
-                .unwrap_or_default()
+                .get_bytes(PROPERTY_ENTROPY)
+                .unwrap_or_else(|_| [0u8; 32].to_vec())
                 .try_into()
                 .map_err(|_| anyhow!("entropy isn't 32 bytes long"))?,
             data_contract: DataContract::from_raw_object(
@@ -132,7 +134,7 @@ impl StateTransitionLike for DataContractCreateTransition {
 
 impl StateTransitionConvert for DataContractCreateTransition {
     fn signature_property_paths() -> Vec<&'static str> {
-        vec![PROPERTY_SIGNATURE]
+        vec![PROPERTY_SIGNATURE, PROPERTY_SIGNATURE_PUBLIC_KEY_ID]
     }
 
     fn identifiers_property_paths() -> Vec<&'static str> {
@@ -140,11 +142,7 @@ impl StateTransitionConvert for DataContractCreateTransition {
     }
 
     fn binary_property_paths() -> Vec<&'static str> {
-        vec![
-            PROPERTY_SIGNATURE,
-            PROPERTY_SIGNATURE_PUBLIC_KEY_ID,
-            PROPERTY_ENTROPY,
-        ]
+        vec![PROPERTY_SIGNATURE, PROPERTY_ENTROPY]
     }
 
     fn to_json(&self) -> Result<JsonValue, ProtocolError> {
@@ -175,5 +173,132 @@ impl StateTransitionConvert for DataContractCreateTransition {
             self.data_contract.to_object(false)?,
         )?;
         Ok(json_object)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        decode_protocol_entity_factory::DecodeProtocolEntity,
+        util::deserializer::get_protocol_version, version,
+    };
+    use serde_json::json;
+
+    use crate::tests::fixtures::get_data_contract_fixture;
+
+    use super::*;
+
+    struct TestData {
+        state_transition: DataContractCreateTransition,
+        data_contract: DataContract,
+    }
+
+    fn get_test_data() -> TestData {
+        let data_contract = get_data_contract_fixture(None);
+
+        let state_transition = DataContractCreateTransition::from_raw_object(json!({
+                    PROPERTY_PROTOCOL_VERSION: version::LATEST_VERSION,
+                                        PROPERTY_ENTROPY : data_contract.entropy,
+                    PROPERTY_DATA_CONTRACT : data_contract.to_object(false).unwrap(),
+        }))
+        .expect("state transition should be created without errors");
+
+        TestData {
+            data_contract,
+            state_transition,
+        }
+    }
+
+    #[test]
+    fn should_return_protocol_version() {
+        let data = get_test_data();
+        assert_eq!(
+            version::LATEST_VERSION,
+            data.state_transition.get_protocol_version()
+        )
+    }
+
+    #[test]
+    fn should_return_transition_type() {
+        let data = get_test_data();
+        assert_eq!(
+            StateTransitionType::DataContractCreate,
+            data.state_transition.get_type()
+        );
+    }
+
+    #[test]
+    fn should_return_data_contract() {
+        let data = get_test_data();
+
+        assert_eq!(
+            data.state_transition
+                .get_data_contract()
+                .to_object(false)
+                .expect("conversion to object shouldn't fail"),
+            data.data_contract
+                .to_object(false)
+                .expect("conversion to object shouldn't fail")
+        );
+    }
+
+    #[test]
+    fn should_return_state_transition_in_json_format() {
+        let data = get_test_data();
+        let mut json_object = data
+            .state_transition
+            .to_json()
+            .expect("conversion to JSON shouldn't fail");
+        println!(
+            "the result is {}",
+            serde_json::to_string_pretty(&json_object).unwrap()
+        );
+
+        assert_eq!(
+            version::LATEST_VERSION,
+            json_object
+                .get_u64(PROPERTY_PROTOCOL_VERSION)
+                .expect("the protocol version should be present") as u32
+        );
+
+        assert_eq!(
+            0,
+            json_object
+                .get_u64(PROPERTY_TRANSITION_TYPE)
+                .expect("the transition type should be present") as u8
+        );
+        assert_eq!(
+            0,
+            json_object
+                .get_u64(PROPERTY_SIGNATURE_PUBLIC_KEY_ID)
+                .expect("default public key id should be defined"),
+        );
+        assert_eq!(
+            "",
+            json_object
+                .remove_into::<String>(PROPERTY_SIGNATURE)
+                .expect("default string value for signature should be present")
+        );
+
+        assert_eq!(
+            base64::encode(data.data_contract.entropy),
+            json_object
+                .remove_into::<String>(PROPERTY_ENTROPY)
+                .expect("the entropy should be present")
+        )
+    }
+
+    #[test]
+    fn should_return_serialized_state_transition_to_buffer() {
+        let data = get_test_data();
+        let state_transition_bytes = data
+            .state_transition
+            .to_buffer(false)
+            .expect("state transition should be converted to buffer");
+        let (protocol_bytes, _) = state_transition_bytes.split_at(4);
+        assert_eq!(
+            version::LATEST_VERSION,
+            get_protocol_version(protocol_bytes).expect("version should be valid")
+        )
     }
 }

--- a/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_create_transition/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         StateTransitionType,
     },
     util::json_value::{JsonValueExt, ReplaceWith},
-    ProtocolError,
+    Convertible, ProtocolError,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/dpp/src/data_contract/state_transition/data_contract_create_transition/validation/state/validate_data_contract_create_transition_state_factory.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_create_transition/validation/state/validate_data_contract_create_transition_state_factory.rs
@@ -1,5 +1,6 @@
 use crate::{
-    errors::StateError, mocks, state_repository::StateRepositoryLike, validation::ValidationResult,
+    data_contract::state_transition::DataContractCreateTransition, errors::StateError,
+    state_repository::StateRepositoryLike, validation::ValidationResult,
 };
 use anyhow::Result;
 
@@ -25,7 +26,7 @@ where
 {
     pub async fn validate_data_contract_create_transition_state(
         &self,
-        state_transition: mocks::StateTransition,
+        state_transition: &DataContractCreateTransition,
     ) -> ValidationResult {
         let mut result = ValidationResult::default();
 

--- a/dpp/src/data_contract/state_transition/data_contract_update_transition/apply_data_contract_update_transition_factory.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_update_transition/apply_data_contract_update_transition_factory.rs
@@ -1,32 +1,32 @@
-use crate::{mocks, state_repository::StateRepositoryLike};
+use crate::state_repository::StateRepositoryLike;
 use anyhow::Result;
 
-pub struct ApplyDataContractUpdateTransitionFactory<SR>
+use super::DataContractUpdateTransition;
+
+pub struct ApplyDataContractUpdateTransition<SR>
 where
     SR: StateRepositoryLike,
 {
     state_repository: SR,
 }
 
-pub fn fetch_documents_factory<SR>(
-    state_repository: SR,
-) -> ApplyDataContractUpdateTransitionFactory<SR>
+pub fn fetch_documents_factory<SR>(state_repository: SR) -> ApplyDataContractUpdateTransition<SR>
 where
     SR: StateRepositoryLike,
 {
-    ApplyDataContractUpdateTransitionFactory { state_repository }
+    ApplyDataContractUpdateTransition { state_repository }
 }
 
-impl<SR> ApplyDataContractUpdateTransitionFactory<SR>
+impl<SR> ApplyDataContractUpdateTransition<SR>
 where
     SR: StateRepositoryLike,
 {
     pub async fn apply_data_contract_update_transition(
         &self,
-        state_transition: mocks::StateTransition,
+        state_transition: &DataContractUpdateTransition,
     ) -> Result<()> {
         self.state_repository
-            .store_data_contract(state_transition.data_contract)
+            .store_data_contract(state_transition.data_contract.clone())
             .await
     }
 }

--- a/dpp/src/data_contract/state_transition/data_contract_update_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_update_transition/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         StateTransitionType,
     },
     util::json_value::{JsonValueExt, ReplaceWith},
-    ProtocolError,
+    Convertible, ProtocolError,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/dpp/src/data_contract/state_transition/data_contract_update_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_update_transition/mod.rs
@@ -150,7 +150,7 @@ impl StateTransitionConvert for DataContractUpdateTransition {
         }
         json_object.insert(
             String::from(PROPERTY_DATA_CONTRACT),
-            self.data_contract.to_object(false)?,
+            self.data_contract.to_object()?,
         )?;
         Ok(json_object)
     }
@@ -175,7 +175,7 @@ mod test {
 
         let state_transition = DataContractUpdateTransition::from_raw_object(json!({
                     PROPERTY_PROTOCOL_VERSION: version::LATEST_VERSION,
-                    PROPERTY_DATA_CONTRACT : data_contract.to_object(false).unwrap(),
+                    PROPERTY_DATA_CONTRACT : data_contract.to_object().unwrap(),
         }))
         .expect("state transition should be created without errors");
 
@@ -210,10 +210,10 @@ mod test {
         assert_eq!(
             data.state_transition
                 .get_data_contract()
-                .to_object(false)
+                .to_object()
                 .expect("conversion to object shouldn't fail"),
             data.data_contract
-                .to_object(false)
+                .to_object()
                 .expect("conversion to object shouldn't fail")
         );
     }

--- a/dpp/src/data_contract/state_transition/data_contract_update_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_update_transition/mod.rs
@@ -1,2 +1,286 @@
 pub mod apply_data_contract_update_transition_factory;
 pub mod validation;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use super::properties::*;
+use crate::{
+    data_contract::DataContract,
+    identity::KeyID,
+    prelude::Identifier,
+    state_transition::{
+        StateTransitionConvert, StateTransitionIdentitySigned, StateTransitionLike,
+        StateTransitionType,
+    },
+    util::json_value::{JsonValueExt, ReplaceWith},
+    ProtocolError,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataContractUpdateTransition {
+    pub protocol_version: u32,
+    #[serde(rename = "type")]
+    pub transition_type: StateTransitionType,
+    // we want to skip serialization of transitions, as we does it manually in `to_object()`  and `to_json()`
+    #[serde(skip_serializing)]
+    pub data_contract: DataContract,
+    pub signature_public_key_id: KeyID,
+    pub signature: Vec<u8>,
+}
+
+impl std::default::Default for DataContractUpdateTransition {
+    fn default() -> Self {
+        DataContractUpdateTransition {
+            protocol_version: Default::default(),
+            transition_type: StateTransitionType::DataContractUpdate,
+            signature_public_key_id: 0,
+            signature: vec![],
+            data_contract: DataContract::default(),
+        }
+    }
+}
+
+impl DataContractUpdateTransition {
+    pub fn from_raw_object(
+        mut raw_data_contract_update_transition: JsonValue,
+    ) -> Result<DataContractUpdateTransition, ProtocolError> {
+        Ok(DataContractUpdateTransition {
+            protocol_version: raw_data_contract_update_transition
+                .get_u64(PROPERTY_PROTOCOL_VERSION)? as u32,
+            signature: raw_data_contract_update_transition
+                .remove_into(PROPERTY_SIGNATURE)
+                .unwrap_or_default(),
+            signature_public_key_id: raw_data_contract_update_transition
+                .get_u64(PROPERTY_SIGNATURE_PUBLIC_KEY_ID)
+                .unwrap_or_default(),
+            data_contract: DataContract::from_raw_object(
+                raw_data_contract_update_transition.remove(PROPERTY_DATA_CONTRACT)?,
+            )?,
+            ..Default::default()
+        })
+    }
+
+    pub fn get_data_contract(&self) -> &DataContract {
+        &self.data_contract
+    }
+
+    pub fn set_data_contract(&mut self, data_contract: DataContract) {
+        self.data_contract = data_contract;
+    }
+
+    /// Get owner ID
+    pub fn get_owner_id(&self) -> &Identifier {
+        &self.data_contract.owner_id
+    }
+
+    /// Returns ID of the created contract
+    pub fn get_modified_data_ids(&self) -> Vec<&Identifier> {
+        vec![&self.data_contract.id]
+    }
+}
+
+impl StateTransitionIdentitySigned for DataContractUpdateTransition {
+    fn get_signature_public_key_id(&self) -> KeyID {
+        self.signature_public_key_id
+    }
+
+    fn set_signature_public_key_id(&mut self, key_id: crate::identity::KeyID) {
+        self.signature_public_key_id = key_id
+    }
+}
+
+impl StateTransitionLike for DataContractUpdateTransition {
+    fn get_protocol_version(&self) -> u32 {
+        self.protocol_version
+    }
+    /// returns the type of State Transition
+    fn get_type(&self) -> StateTransitionType {
+        self.transition_type
+    }
+    /// returns the signature as a byte-array
+    fn get_signature(&self) -> &Vec<u8> {
+        &self.signature
+    }
+    /// set a new signature
+    fn set_signature(&mut self, signature: Vec<u8>) {
+        self.signature = signature
+    }
+    fn calculate_fee(&self) -> Result<u64, ProtocolError> {
+        todo!("fee calculation")
+    }
+}
+
+impl StateTransitionConvert for DataContractUpdateTransition {
+    fn signature_property_paths() -> Vec<&'static str> {
+        vec![PROPERTY_SIGNATURE, PROPERTY_SIGNATURE_PUBLIC_KEY_ID]
+    }
+
+    fn identifiers_property_paths() -> Vec<&'static str> {
+        vec![]
+    }
+
+    fn binary_property_paths() -> Vec<&'static str> {
+        vec![PROPERTY_SIGNATURE, PROPERTY_ENTROPY]
+    }
+
+    fn to_json(&self) -> Result<JsonValue, ProtocolError> {
+        let mut json_value: JsonValue = serde_json::to_value(self)?;
+        json_value.replace_binary_paths(Self::binary_property_paths(), ReplaceWith::Base64)?;
+        json_value
+            .replace_identifier_paths(Self::identifiers_property_paths(), ReplaceWith::Base58)?;
+
+        json_value.insert(
+            PROPERTY_DATA_CONTRACT.to_string(),
+            self.data_contract.to_json()?,
+        )?;
+
+        Ok(json_value)
+    }
+
+    fn to_object(&self, skip_signature: bool) -> Result<JsonValue, ProtocolError> {
+        let mut json_object: JsonValue = serde_json::to_value(self)?;
+        if skip_signature {
+            if let JsonValue::Object(ref mut o) = json_object {
+                for path in Self::signature_property_paths() {
+                    o.remove(path);
+                }
+            }
+        }
+        json_object.insert(
+            String::from(PROPERTY_DATA_CONTRACT),
+            self.data_contract.to_object(false)?,
+        )?;
+        Ok(json_object)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{util::deserializer::get_protocol_version, version};
+    use serde_json::json;
+
+    use crate::tests::fixtures::get_data_contract_fixture;
+
+    use super::*;
+
+    struct TestData {
+        state_transition: DataContractUpdateTransition,
+        data_contract: DataContract,
+    }
+
+    fn get_test_data() -> TestData {
+        let data_contract = get_data_contract_fixture(None);
+
+        let state_transition = DataContractUpdateTransition::from_raw_object(json!({
+                    PROPERTY_PROTOCOL_VERSION: version::LATEST_VERSION,
+                    PROPERTY_DATA_CONTRACT : data_contract.to_object(false).unwrap(),
+        }))
+        .expect("state transition should be created without errors");
+
+        TestData {
+            data_contract,
+            state_transition,
+        }
+    }
+
+    #[test]
+    fn should_return_protocol_version() {
+        let data = get_test_data();
+        assert_eq!(
+            version::LATEST_VERSION,
+            data.state_transition.get_protocol_version()
+        )
+    }
+
+    #[test]
+    fn should_return_transition_type() {
+        let data = get_test_data();
+        assert_eq!(
+            StateTransitionType::DataContractUpdate,
+            data.state_transition.get_type()
+        );
+    }
+
+    #[test]
+    fn should_return_data_contract() {
+        let data = get_test_data();
+
+        assert_eq!(
+            data.state_transition
+                .get_data_contract()
+                .to_object(false)
+                .expect("conversion to object shouldn't fail"),
+            data.data_contract
+                .to_object(false)
+                .expect("conversion to object shouldn't fail")
+        );
+    }
+
+    #[test]
+    fn should_return_state_transition_in_json_format() {
+        let data = get_test_data();
+        let mut json_object = data
+            .state_transition
+            .to_json()
+            .expect("conversion to JSON shouldn't fail");
+
+        assert_eq!(
+            version::LATEST_VERSION,
+            json_object
+                .get_u64(PROPERTY_PROTOCOL_VERSION)
+                .expect("the protocol version should be present") as u32
+        );
+
+        assert_eq!(
+            4,
+            json_object
+                .get_u64(PROPERTY_TRANSITION_TYPE)
+                .expect("the transition type should be present") as u8
+        );
+        assert_eq!(
+            0,
+            json_object
+                .get_u64(PROPERTY_SIGNATURE_PUBLIC_KEY_ID)
+                .expect("default public key id should be defined"),
+        );
+        assert_eq!(
+            "",
+            json_object
+                .remove_into::<String>(PROPERTY_SIGNATURE)
+                .expect("default string value for signature should be present")
+        );
+    }
+
+    #[test]
+    fn should_return_serialized_state_transition_to_buffer() {
+        let data = get_test_data();
+        let state_transition_bytes = data
+            .state_transition
+            .to_buffer(false)
+            .expect("state transition should be converted to buffer");
+        let (protocol_bytes, _) = state_transition_bytes.split_at(4);
+        assert_eq!(
+            version::LATEST_VERSION,
+            get_protocol_version(protocol_bytes).expect("version should be valid")
+        )
+    }
+
+    #[test]
+    fn should_return_owner_id() {
+        let data = get_test_data();
+        assert_eq!(
+            &data.data_contract.owner_id,
+            data.state_transition.get_owner_id()
+        );
+    }
+
+    #[test]
+    fn is_data_contract_state_transition() {
+        let data = get_test_data();
+        assert!(data.state_transition.is_data_contract_state_transition());
+        assert!(!data.state_transition.is_document_state_transition());
+        assert!(!data.state_transition.is_identity_state_transition());
+    }
+}

--- a/dpp/src/data_contract/state_transition/data_contract_update_transition/validation/state/validate_data_contract_update_transition_state_factory.rs
+++ b/dpp/src/data_contract/state_transition/data_contract_update_transition/validation/state/validate_data_contract_update_transition_state_factory.rs
@@ -1,6 +1,8 @@
 use crate::{
-    data_contract::DataContract, errors::consensus::basic::BasicError, mocks,
-    state_repository::StateRepositoryLike, validation::ValidationResult,
+    data_contract::{state_transition::DataContractUpdateTransition, DataContract},
+    errors::consensus::basic::BasicError,
+    state_repository::StateRepositoryLike,
+    validation::ValidationResult,
 };
 use anyhow::Result;
 
@@ -21,7 +23,7 @@ where
 
     pub async fn validate_data_contract_update_transition_state(
         &self,
-        state_transition: mocks::StateTransition,
+        state_transition: &DataContractUpdateTransition,
     ) -> ValidationResult {
         let mut result = ValidationResult::default();
 
@@ -36,7 +38,7 @@ where
             // general error we want to add the same result
             Ok(None) | Err(_) => {
                 let err = BasicError::DataContractContPresent {
-                    data_contract_id: state_transition.data_contract.id,
+                    data_contract_id: state_transition.data_contract.id.clone(),
                 };
                 result.add_error(err);
                 return result;

--- a/dpp/src/data_contract/state_transition/mod.rs
+++ b/dpp/src/data_contract/state_transition/mod.rs
@@ -1,5 +1,14 @@
+mod data_contract_update_transition;
+pub use data_contract_update_transition::*;
+
 mod data_contract_create_transition;
 pub use data_contract_create_transition::*;
 
-mod data_contract_update_transition;
-pub use data_contract_update_transition::*;
+pub(self) mod properties {
+    pub const PROPERTY_SIGNATURE_PUBLIC_KEY_ID: &str = "signaturePublicKeyId";
+    pub const PROPERTY_DATA_CONTRACT: &str = "dataContract";
+    pub const PROPERTY_SIGNATURE: &str = "signature";
+    pub const PROPERTY_ENTROPY: &str = "entropy";
+    pub const PROPERTY_PROTOCOL_VERSION: &str = "protocolVersion";
+    pub const PROPERTY_TRANSITION_TYPE: &str = "type";
+}

--- a/dpp/src/document/mod.rs
+++ b/dpp/src/document/mod.rs
@@ -100,7 +100,7 @@ impl Document {
         let mut json_value: JsonValue = ciborium::de::from_reader(document_bytes)
             .map_err(|e| ProtocolError::EncodingError(format!("{}", e)))?;
 
-        json_value.parse_and_add_protocol_version(protocol_bytes)?;
+        json_value.parse_and_add_protocol_version("$protocolVersion", protocol_bytes)?;
         // TODO identifiers and binary data for dynamic values
         json_value.replace_identifier_paths(IDENTIFIER_FIELDS, ReplaceWith::Base58)?;
 

--- a/dpp/src/document/state_transition/documents_batch_transition/mod.rs
+++ b/dpp/src/document/state_transition/documents_batch_transition/mod.rs
@@ -21,14 +21,14 @@ pub mod document_transition;
 pub mod validation;
 use serde_json::Value as JsonValue;
 
-pub const PROPERTY_DATA_CONTRACT_ID: &str = "$dataContractId";
-pub const PROPERTY_TRANSITIONS: &str = "transitions";
-pub const PROPERTY_OWNER_ID: &str = "ownerId";
-pub const PROPERTY_SIGNATURE_PUBLIC_KEY_ID: &str = "signaturePublicKeyId";
-pub const PROPERTY_SIGNATURE: &str = "signature";
-pub const PROPERTY_PROTOCOL_VERSION: &str = "protocolVersion";
-pub const PROPERTY_SECURITY_LEVEL_REQUIREMENT: &str = "signatureSecurityLevelRequirement";
-pub const DEFAULT_SECURITY_LEVEL: SecurityLevel = SecurityLevel::HIGH;
+const PROPERTY_DATA_CONTRACT_ID: &str = "$dataContractId";
+const PROPERTY_TRANSITIONS: &str = "transitions";
+const PROPERTY_OWNER_ID: &str = "ownerId";
+const PROPERTY_SIGNATURE_PUBLIC_KEY_ID: &str = "signaturePublicKeyId";
+const PROPERTY_SIGNATURE: &str = "signature";
+const PROPERTY_PROTOCOL_VERSION: &str = "protocolVersion";
+const PROPERTY_SECURITY_LEVEL_REQUIREMENT: &str = "signatureSecurityLevelRequirement";
+const DEFAULT_SECURITY_LEVEL: SecurityLevel = SecurityLevel::HIGH;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/dpp/src/lib.rs
+++ b/dpp/src/lib.rs
@@ -4,6 +4,7 @@ mod contracts;
 pub mod data_contract;
 extern crate core;
 
+mod convertible;
 pub mod data_trigger;
 pub mod decode_protocol_entity_factory;
 pub mod document;
@@ -22,6 +23,7 @@ pub mod validation;
 
 mod dash_platform_protocol;
 
+pub use convertible::Convertible;
 pub use dash_platform_protocol::DashPlatformProtocol;
 pub use errors::*;
 pub mod mocks;
@@ -30,6 +32,7 @@ pub mod mocks;
 mod tests;
 
 mod prelude {
+    pub use super::convertible::Convertible;
     pub use crate::data_contract::DataContract;
     pub use crate::data_trigger::DataTrigger;
     pub use crate::document::document_transition::DocumentTransition;

--- a/dpp/src/mocks.rs
+++ b/dpp/src/mocks.rs
@@ -47,10 +47,6 @@ pub struct JsonSchemaValidator {}
 
 pub trait JsonSchemaValidatorLike {}
 
-pub struct StateTransition {
-    pub data_contract: DataContract,
-}
-
 pub struct SimplifiedMNList {}
 impl SimplifiedMNList {
     pub fn get_valid_master_nodes(&self) -> Vec<SMLEntry> {
@@ -79,40 +75,6 @@ impl SMLStore {
         unimplemented!()
     }
 }
-
-// #[derive(Debug, Clone, Serialize, Deserialize)]
-// pub struct DataContractUpdateTransition {}
-// impl StateTransitionConvert for DataContractUpdateTransition {
-//     fn signature_property_paths() -> Vec<&'static str> {
-//         unimplemented!()
-//     }
-//     fn identifiers_property_paths() -> Vec<&'static str> {
-//         unimplemented!()
-//     }
-//     fn binary_property_paths() -> Vec<&'static str> {
-//         unimplemented!()
-//     }
-// }
-// impl StateTransitionLike for DataContractUpdateTransition {
-//     fn get_protocol_version(&self) -> u32 {
-//         unimplemented!()
-//     }
-//     /// returns the type of State Transition
-//     fn get_type(&self) -> StateTransitionType {
-//         unimplemented!()
-//     }
-//     /// returns the signature as a byte-array
-//     fn get_signature(&self) -> &Vec<u8> {
-//         unimplemented!()
-//     }
-//     /// set a new signature
-//     fn set_signature(&mut self, _signature: Vec<u8>) {
-//         unimplemented!()
-//     }
-//     fn calculate_fee(&self) -> Result<u64, ProtocolError> {
-//         unimplemented!()
-//     }
-// }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdentityCreateTransition {}

--- a/dpp/src/mocks.rs
+++ b/dpp/src/mocks.rs
@@ -80,39 +80,39 @@ impl SMLStore {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DataContractUpdateTransition {}
-impl StateTransitionConvert for DataContractUpdateTransition {
-    fn signature_property_paths() -> Vec<&'static str> {
-        unimplemented!()
-    }
-    fn identifiers_property_paths() -> Vec<&'static str> {
-        unimplemented!()
-    }
-    fn binary_property_paths() -> Vec<&'static str> {
-        unimplemented!()
-    }
-}
-impl StateTransitionLike for DataContractUpdateTransition {
-    fn get_protocol_version(&self) -> u32 {
-        unimplemented!()
-    }
-    /// returns the type of State Transition
-    fn get_type(&self) -> StateTransitionType {
-        unimplemented!()
-    }
-    /// returns the signature as a byte-array
-    fn get_signature(&self) -> &Vec<u8> {
-        unimplemented!()
-    }
-    /// set a new signature
-    fn set_signature(&mut self, _signature: Vec<u8>) {
-        unimplemented!()
-    }
-    fn calculate_fee(&self) -> Result<u64, ProtocolError> {
-        unimplemented!()
-    }
-}
+// #[derive(Debug, Clone, Serialize, Deserialize)]
+// pub struct DataContractUpdateTransition {}
+// impl StateTransitionConvert for DataContractUpdateTransition {
+//     fn signature_property_paths() -> Vec<&'static str> {
+//         unimplemented!()
+//     }
+//     fn identifiers_property_paths() -> Vec<&'static str> {
+//         unimplemented!()
+//     }
+//     fn binary_property_paths() -> Vec<&'static str> {
+//         unimplemented!()
+//     }
+// }
+// impl StateTransitionLike for DataContractUpdateTransition {
+//     fn get_protocol_version(&self) -> u32 {
+//         unimplemented!()
+//     }
+//     /// returns the type of State Transition
+//     fn get_type(&self) -> StateTransitionType {
+//         unimplemented!()
+//     }
+//     /// returns the signature as a byte-array
+//     fn get_signature(&self) -> &Vec<u8> {
+//         unimplemented!()
+//     }
+//     /// set a new signature
+//     fn set_signature(&mut self, _signature: Vec<u8>) {
+//         unimplemented!()
+//     }
+//     fn calculate_fee(&self) -> Result<u64, ProtocolError> {
+//         unimplemented!()
+//     }
+// }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdentityCreateTransition {}

--- a/dpp/src/mocks.rs
+++ b/dpp/src/mocks.rs
@@ -80,43 +80,6 @@ impl SMLStore {
     }
 }
 
-// State Transitions mocks:
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DataContractCreateTransition {}
-
-impl StateTransitionConvert for DataContractCreateTransition {
-    fn signature_property_paths() -> Vec<&'static str> {
-        unimplemented!()
-    }
-    fn identifiers_property_paths() -> Vec<&'static str> {
-        unimplemented!()
-    }
-    fn binary_property_paths() -> Vec<&'static str> {
-        unimplemented!()
-    }
-}
-impl StateTransitionLike for DataContractCreateTransition {
-    fn get_protocol_version(&self) -> u32 {
-        unimplemented!()
-    }
-    /// returns the type of State Transition
-    fn get_type(&self) -> StateTransitionType {
-        unimplemented!()
-    }
-    /// returns the signature as a byte-array
-    fn get_signature(&self) -> &Vec<u8> {
-        unimplemented!()
-    }
-    /// set a new signature
-    fn set_signature(&mut self, _signature: Vec<u8>) {
-        unimplemented!()
-    }
-    fn calculate_fee(&self) -> Result<u64, ProtocolError> {
-        unimplemented!()
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataContractUpdateTransition {}
 impl StateTransitionConvert for DataContractUpdateTransition {

--- a/dpp/src/state_transition/abstract_state_transition.rs
+++ b/dpp/src/state_transition/abstract_state_transition.rs
@@ -173,15 +173,6 @@ pub trait StateTransitionConvert: Serialize {
         json_value
             .replace_identifier_paths(Self::identifiers_property_paths(), ReplaceWith::Base58)?;
 
-        // https://github.com/dashevo/platform/blob/9c8e6a3b6afbc330a6ab551a689de8ccd63f9120/packages/js-dpp/lib/stateTransition/AbstractStateTransition.js#L120
-        // the logic presented in the link suggests that `signature` property is present in JSON only if its not empty. Which
-        // introduces the inconsistency between the object representation and JSON representation
-        if let Some(JsonValue::String(value)) = json_value.get(PROPERTY_SIGNATURE) {
-            if value.is_empty() {
-                let _ = json_value.remove(PROPERTY_SIGNATURE);
-            }
-        }
-
         Ok(json_value)
     }
 

--- a/dpp/src/state_transition/abstract_state_transition_identity_signed.rs
+++ b/dpp/src/state_transition/abstract_state_transition_identity_signed.rs
@@ -146,7 +146,6 @@ mod test {
     use crate::{
         assert_error_contains,
         identity::{KeyID, SecurityLevel},
-        mocks,
         state_transition::{
             StateTransition, StateTransitionConvert, StateTransitionLike, StateTransitionType,
         },

--- a/dpp/src/state_transition/mod.rs
+++ b/dpp/src/state_transition/mod.rs
@@ -1,3 +1,5 @@
+use crate::data_contract::state_transition::DataContractCreateTransition;
+// TODO unify the import paths ::object::state_transition::*
 use crate::document::DocumentsBatchTransition;
 mod state_transition_types;
 use serde::{Deserialize, Serialize};
@@ -38,9 +40,7 @@ macro_rules! call_method {
 macro_rules! call_static_method {
     ($state_transition:expr, $method:ident ) => {
         match $state_transition {
-            StateTransition::DataContractCreate(_) => {
-                mocks::DataContractCreateTransition::$method()
-            }
+            StateTransition::DataContractCreate(_) => DataContractCreateTransition::$method(),
             StateTransition::DataContractUpdate(_) => {
                 mocks::DataContractUpdateTransition::$method()
             }
@@ -53,7 +53,7 @@ macro_rules! call_static_method {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum StateTransition {
-    DataContractCreate(mocks::DataContractCreateTransition),
+    DataContractCreate(DataContractCreateTransition),
     DataContractUpdate(mocks::DataContractUpdateTransition),
     DocumentsBatch(DocumentsBatchTransition),
     IdentityCreate(mocks::IdentityCreateTransition),
@@ -127,8 +127,8 @@ impl StateTransitionLike for StateTransition {
     }
 }
 
-impl From<mocks::DataContractCreateTransition> for StateTransition {
-    fn from(d: mocks::DataContractCreateTransition) -> Self {
+impl From<DataContractCreateTransition> for StateTransition {
+    fn from(d: DataContractCreateTransition) -> Self {
         Self::DataContractCreate(d)
     }
 }

--- a/dpp/src/state_transition/mod.rs
+++ b/dpp/src/state_transition/mod.rs
@@ -1,4 +1,6 @@
-use crate::data_contract::state_transition::DataContractCreateTransition;
+use crate::data_contract::state_transition::{
+    DataContractCreateTransition, DataContractUpdateTransition,
+};
 // TODO unify the import paths ::object::state_transition::*
 use crate::document::DocumentsBatchTransition;
 mod state_transition_types;
@@ -41,9 +43,7 @@ macro_rules! call_static_method {
     ($state_transition:expr, $method:ident ) => {
         match $state_transition {
             StateTransition::DataContractCreate(_) => DataContractCreateTransition::$method(),
-            StateTransition::DataContractUpdate(_) => {
-                mocks::DataContractUpdateTransition::$method()
-            }
+            StateTransition::DataContractUpdate(_) => DataContractUpdateTransition::$method(),
             StateTransition::DocumentsBatch(_) => DocumentsBatchTransition::$method(),
             StateTransition::IdentityCreate(_) => mocks::IdentityCreateTransition::$method(),
             StateTransition::IdentityTopUp(_) => mocks::IdentityTopUpTransition::$method(),
@@ -54,7 +54,7 @@ macro_rules! call_static_method {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum StateTransition {
     DataContractCreate(DataContractCreateTransition),
-    DataContractUpdate(mocks::DataContractUpdateTransition),
+    DataContractUpdate(DataContractUpdateTransition),
     DocumentsBatch(DocumentsBatchTransition),
     IdentityCreate(mocks::IdentityCreateTransition),
     IdentityTopUp(mocks::IdentityTopUpTransition),
@@ -133,8 +133,8 @@ impl From<DataContractCreateTransition> for StateTransition {
     }
 }
 
-impl From<mocks::DataContractUpdateTransition> for StateTransition {
-    fn from(d: mocks::DataContractUpdateTransition) -> Self {
+impl From<DataContractUpdateTransition> for StateTransition {
+    fn from(d: DataContractUpdateTransition) -> Self {
         Self::DataContractUpdate(d)
     }
 }

--- a/dpp/src/util/deserializer.rs
+++ b/dpp/src/util/deserializer.rs
@@ -24,7 +24,7 @@ pub fn get_protocol_version(version_bytes: &[u8]) -> Result<u32, ProtocolError> 
         .into());
     } else {
         let version_set_bytes: [u8; 4] = version_bytes.try_into().unwrap();
-        u32::from_be_bytes(version_set_bytes)
+        u32::from_le_bytes(version_set_bytes)
     })
 }
 

--- a/js-binding/src/data_contract/data_contract.rs
+++ b/js-binding/src/data_contract/data_contract.rs
@@ -12,6 +12,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::identifier::IdentifierWrapper;
 use crate::metadata::MetadataWasm;
+use dpp::Convertible;
 
 #[wasm_bindgen(js_name=DataContract)]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
imlementation transitions:
 -> `DataContractCreateTransition`
 -> `DataContractUpdateTransition`
 ->  fix `to_buffer()` / `from_buffer` methods for `DataContract`
 ->  extract the trait `Convertible` for DPP structures