### PR TITLE
fix: `Identity.balance` was of type `i64` but should be `u64`

### DIFF
--- a/dpp/src/identity/identity.rs
+++ b/dpp/src/identity/identity.rs
@@ -33,7 +33,7 @@ pub struct Identity {
     pub protocol_version: u32,
     pub id: Identifier,
     pub public_keys: Vec<IdentityPublicKey>,
-    pub balance: i64,
+    pub balance: u64,
     pub revision: i64,
     #[serde(skip)]
     pub asset_lock_proof: Option<AssetLockProof>,
@@ -47,7 +47,7 @@ struct IdentityForBuffer {
     // TODO the struct probably should be made from references
     id: Identifier,
     public_keys: Vec<IdentityPublicKey>,
-    balance: i64,
+    balance: u64,
     revision: i64,
 }
 
@@ -90,25 +90,25 @@ impl Identity {
     }
 
     /// Returns balance
-    pub fn get_balance(&self) -> i64 {
+    pub fn get_balance(&self) -> u64 {
         self.balance
     }
 
     /// Set Identity balance
-    pub fn set_balance(mut self, balance: i64) -> Self {
+    pub fn set_balance(mut self, balance: u64) -> Self {
         self.balance = balance;
         self
     }
 
     /// Increase Identity balance
     pub fn increase_balance(mut self, amount: u64) -> Self {
-        self.balance += amount as i64;
+        self.balance += amount;
         self
     }
 
     /// Reduce the Identity balance
     pub fn reduce_balance(mut self, amount: u64) -> Self {
-        self.balance -= amount as i64;
+        self.balance -= amount;
         self
     }
 
@@ -191,7 +191,7 @@ impl Identity {
 
         let identity_id = identity_map.get_identifier("id")?;
         let revision = identity_map.get_i64("revision")?;
-        let balance: i64 = identity_map.get_i64("balance")?;
+        let balance: u64 = identity_map.get_u64("balance")?;
 
         let keys_cbor_value = identity_map.get("publicKeys").ok_or_else(|| {
             ProtocolError::DecodingError(String::from(

--- a/dpp/src/util/cbor_value.rs
+++ b/dpp/src/util/cbor_value.rs
@@ -72,6 +72,7 @@ pub trait CborBTreeMapHelper {
     fn get_string(&self, key: &str) -> Result<String, ProtocolError>;
     fn get_u32(&self, key: &str) -> Result<u32, ProtocolError>;
     fn get_i64(&self, key: &str) -> Result<i64, ProtocolError>;
+    fn get_u64(&self, key: &str) -> Result<u64, ProtocolError>;
 }
 
 impl CborBTreeMapHelper for BTreeMap<String, CborValue> {
@@ -109,6 +110,15 @@ impl CborBTreeMapHelper for BTreeMap<String, CborValue> {
             .ok_or_else(|| ProtocolError::DecodingError(format!("{key} must be an integer")))?
             .try_into()
             .map_err(|_| ProtocolError::DecodingError(format!("{key} must be a 64 int")))
+    }
+
+    fn get_u64(&self, key: &str) -> Result<u64, ProtocolError> {
+        self.get(key)
+            .ok_or_else(|| ProtocolError::DecodingError(format!("unable to get property {key}")))?
+            .as_integer()
+            .ok_or_else(|| ProtocolError::DecodingError(format!("{key} must be an integer")))?
+            .try_into()
+            .map_err(|_| ProtocolError::DecodingError(format!("{key} must be a 64 uint")))
     }
 }
 

--- a/js-binding/src/identity.rs
+++ b/js-binding/src/identity.rs
@@ -58,12 +58,12 @@ impl IdentityWasm {
     }
 
     #[wasm_bindgen(js_name=getBalance)]
-    pub fn get_balance(&self) -> i64 {
+    pub fn get_balance(&self) -> u64 {
         self.0.get_balance()
     }
 
     #[wasm_bindgen(js_name=setBalance)]
-    pub fn set_balance(mut self, balance: i64) -> Self {
+    pub fn set_balance(mut self, balance: u64) -> Self {
         self.0 = self.0.set_balance(balance);
         self
     }


### PR DESCRIPTION
Originally set to `i64` identity balance should be `u64` since we're not allowing for negative balance.